### PR TITLE
Correction erreur ODT & support `ObjectReplacements`

### DIFF
--- a/lib/ODConverter.js
+++ b/lib/ODConverter.js
@@ -1,61 +1,94 @@
-var odpMdWriter = require("./ODPMDWriter");
-var odtMdWriter = require("./ODTMDWriter");
-var Promise = require("bluebird");
+var odpMdWriter = require('./ODPMDWriter');
+var odtMdWriter = require('./ODTMDWriter');
+var Promise = require('bluebird');
 var path = require('path');
-var sax = require("sax");
+var sax = require('sax');
 var AdmZip = require('adm-zip');
-var fs = Promise.promisifyAll(require("fs"));
+var fs = Promise.promisifyAll(require('fs'));
 var _ = require('lodash');
 
-var imgDir = 'ressources/images';
+var imageOutputSubFolder = 'ressources/images';
 
-module.exports.convert = function (filePath, outDir, splitFiles) {
+module.exports.convert = function (sourceFilePath, outputFolder, splitFiles) {
   return Promise.try(function () {
 
-    var extension = path.extname(filePath);
+    var extension = path.extname(sourceFilePath);
 
-    if (extension !== ".odp" && extension !== ".odt") {
-      throw new Error("fichier non supporté " + extension);
+    if (extension !== '.odp' && extension !== '.odt') {
+      throw new Error('fichier non supporté ' + extension);
     }
 
-    var mdWriter;
-    if (extension === ".odp") {
-      mdWriter = new odpMdWriter();
-    } else {
-      mdWriter = new odtMdWriter();
-    }
+    var mdWriter = createWriter(extension);
 
-    var outputFileName = toFileName(path.basename(filePath, extension));
-    var contentName = path.join(outDir, outputFileName + '-content.xml');
+    var outputFileName = toFileName(path.basename(sourceFilePath, extension));
+    var contentName = path.join(outputFolder, outputFileName + '-content.xml');
 
-    extractOd(filePath, outputFileName, contentName, outDir);
+    extractOd(sourceFilePath, outputFileName, contentName, outputFolder);
 
-    return convertToMd(contentName, outputFileName, mdWriter, outDir, splitFiles);
+    return convertToMd(contentName, outputFileName, mdWriter, outputFolder, splitFiles);
   });
 };
+
+function createWriter(extension) {
+  var mdWriter;
+  if (extension === '.odp') {
+    mdWriter = new odpMdWriter();
+  } else if (extension === '.odt') {
+    mdWriter = new odtMdWriter();
+  } else {
+    throw new Error('fichier non supporté ' + extension);
+  }
+  return mdWriter;
+}
 
 function toFileName(name) {
   return name.toLowerCase().replace(/[\s-]+/g, '_').replace(/_{2,}/g, "_");
 }
 
-function extractOd(filePath, outputFileName, contentName, outDir) {
-  console.log('extract : ' + filePath);
+function extractOd(sourceFilePath, outputFileName, contentName, outputFolder) {
+  console.log('extract : ' + sourceFilePath);
 
-  var zip = new AdmZip(filePath);
+  var zip = new AdmZip(sourceFilePath);
   var zipEntries = zip.getEntries();
-  zipEntries.forEach(function (val) {
-    if (val.entryName.indexOf("content.xml") >= 0) {
-      //console.log(val.entryName);
-      zip.extractEntryTo(val, outDir, true, true);
-      fs.renameSync(path.join(outDir, val.entryName), contentName);
+  zipEntries.forEach(function (entry) {
+
+    // console.log(entry.entryName);
+
+    // extract text content
+    if (entry.entryName.indexOf('content.xml') >= 0) {
+      extractContent(zip, entry, outputFolder, contentName);
     }
-    if (val.entryName.indexOf("Pictures") >= 0) {
-      //console.log(val.entryName);
-      zip.extractEntryTo(val, path.join(outDir, imgDir), false, true);
-      var baseName = path.basename(val.entryName);
-      fs.renameSync(path.join(outDir, imgDir, baseName), path.join(outDir, imgDir, outputFileName + '-' + baseName));
+    // extract pictures
+    else if (entry.entryName.indexOf('Pictures') >= 0) {
+      extractPictures(zip, entry, outputFolder, outputFileName);
     }
+    // extract object
+    else if (entry.entryName.indexOf('ObjectReplacements') >= 0) {
+      extractObjectReplacements(zip, entry, outputFolder, outputFileName);
+    }
+
   });
+}
+
+function extractContent(zip, entry, outputFolder, contentName) {
+  zip.extractEntryTo(entry, outputFolder, true, true);
+  fs.renameSync(path.join(outputFolder, entry.entryName), contentName);
+}
+
+function extractPictures(zip, entry, outputFolder, outputFileName) {
+  zip.extractEntryTo(entry, path.join(outputFolder, imageOutputSubFolder), false, true);
+  var baseName = path.basename(entry.entryName);
+  fs.renameSync(path.join(outputFolder, imageOutputSubFolder, baseName), path.join(outputFolder, imageOutputSubFolder, outputFileName + '-' + baseName));
+}
+
+function extractObjectReplacements(zip, entry, outputFolder, outputFileName) {
+  zip.extractEntryTo(entry, path.join(outputFolder, imageOutputSubFolder), false, true);
+  var baseName = path.basename(entry.entryName);
+  fs.renameSync(path.join(outputFolder, imageOutputSubFolder, baseName), path.join(outputFolder, imageOutputSubFolder, outputFileName + '-' + toFileName(baseName) + '.svm'));
+}
+
+function buildObjectReplacementsFilename(nameReference) {
+  return toFileName(nameReference.replace('./ObjectReplacements/', '')) + '.svm';
 }
 
 function convertToMd(contentName, outputFileName, mdWriter, outDir, splitFiles) {
@@ -68,73 +101,84 @@ function convertToMd(contentName, outputFileName, mdWriter, outDir, splitFiles) 
       lowercase: true
     });
 
-    saxStream.on("opentag", function (node) {
+    saxStream.on('opentag', function (node) {
 
-      if (node.name === "draw:page") {
+      if (node.name === 'draw:page') {
         mdWriter.addPage();
-      } else if (node.name === "draw:image") {
-        mdWriter.addImage(outputFileName + '-' + node.attributes["xlink:href"]);
-      } else if (node.name === "text:list") {
+      } else if (node.name === 'draw:image') {
+        var nameReference = node.attributes['xlink:href'];
+
+        if (nameReference.indexOf('ObjectReplacements') >= 0) {
+          nameReference = buildObjectReplacementsFilename(nameReference);
+        }
+
+        mdWriter.addImage(outputFileName + '-' + nameReference);
+      } else if (node.name === 'text:list') {
         mdWriter.startList();
-      } else if (node.name === "text:list-item") {
+      } else if (node.name === 'text:list-item') {
         mdWriter.addBullet();
-      } else if (node.name === "draw:custom-shape" || node.name === "draw:rect") {
+      } else if (node.name === 'draw:custom-shape' || node.name === 'draw:rect') {
         mdWriter.startCodeBlock();
-      } else if (node.name === "text:p") {
+      } else if (node.name === 'text:p') {
         mdWriter.addParagraph();
-      } else if (node.name === "text:h") {
-        mdWriter.startTitle(parseInt(node.attributes["text:outline-level"]));
-      } else if (node.name === "presentation:notes") {
+      } else if (node.name === 'text:h') {
+        mdWriter.startTitle(parseInt(node.attributes['text:outline-level']));
+      } else if (node.name === 'presentation:notes') {
         mdWriter.startNotes();
-      } else if (node.name === "table:table") {
+      } else if (node.name === 'table:table') {
         mdWriter.startTable();
-      } else if (node.name === "table:table-row") {
+      } else if (node.name === 'table:table-row') {
         mdWriter.startRow();
-      } else if (node.name === "text:line-break") {
+      } else if (node.name === 'text:line-break') {
         mdWriter.lineBreak();
+      } else {
+        // console.log('opentag:', node.name, node);
       }
 
     });
 
-    saxStream.on("closetag", function (node) {
+    saxStream.on('closetag', function (node) {
 
-      if (node === "draw:custom-shape" || node === "draw:rect") {
+      if (node === 'draw:custom-shape' || node === 'draw:rect') {
         mdWriter.endCodeBlock();
-      } else if (node === "text:list") {
+      } else if (node === 'text:list') {
         mdWriter.endList();
-      } else if (node === "presentation:notes") {
+      } else if (node === 'presentation:notes') {
         mdWriter.endNotes();
-      } else if (node === "table:table") {
+      } else if (node === 'table:table') {
         mdWriter.endTable();
-      } else if (node === "table:table-cell") {
+      } else if (node === 'table:table-cell') {
         mdWriter.closeCell();
-      } else if (node === "text:p") {
+      } else if (node === 'text:p') {
         mdWriter.endParagraph();
-      } else if (node === "text:h") {
+      } else if (node === 'text:h') {
         mdWriter.endTitle();
-      } else if (node === "text:list-item") {
+      } else if (node === 'text:list-item') {
         mdWriter.endBullet();
+      } else {
+        // console.log('closetag:', node);
       }
+
     });
 
-    saxStream.on("end", function () {
+    saxStream.on('end', function () {
       console.log('end');
       mdWriter.addEnd();
     });
 
-    saxStream.on("text", function (text) {
+    saxStream.on('text', function (text) {
       mdWriter.addText(text);
     });
 
     fs.createReadStream(contentName)
-      .once("readable", function () {
+      .once('readable', function () {
         console.log('convert : ' + outputFileName);
       })
       .pipe(saxStream)
-      .on("end", function () {
+      .on('end', function () {
         resolve(mdWriter);
       })
-      .on("error", reject);
+      .on('error', reject);
 
   }).then(function (mdWriter) {
 
@@ -146,7 +190,7 @@ function convertToMd(contentName, outputFileName, mdWriter, outDir, splitFiles) 
     if (!splitFiles && mdWriter.pages) {
       mdWriter.text = _.map(mdWriter.pages, function (page) {
         return page.text;
-      }).join("");
+      }).join('');
     }
 
     if (mdWriter.text) {

--- a/lib/ODConverter.js
+++ b/lib/ODConverter.js
@@ -9,155 +9,164 @@ var _ = require('lodash');
 
 var imgDir = 'ressources/images';
 
-module.exports.convert = function(filePath, outDir, splitFiles) {
-    return Promise.try(function() {
-        var extension = path.extname(filePath);
-        if (extension !== ".odp" && extension !== ".odt") {
-            throw new Error("fichier non supporté " + extension);
-        }
-        var name = toFileName(path.basename(filePath, extension));
-        var contentName = path.join(outDir, name + '-content.xml');
+module.exports.convert = function (filePath, outDir, splitFiles) {
+  return Promise.try(function () {
 
-        var mdWriter;
-        if (extension === ".odp") {
-            mdWriter = new odpMdWriter();
-        } else {
-            mdWriter = new odtMdWriter();
-        }
+    var extension = path.extname(filePath);
 
-        extractOd(filePath, name, contentName, outDir);
-        return convertToMd(contentName, name, mdWriter, outDir, splitFiles);
-    });
-}
+    if (extension !== ".odp" && extension !== ".odt") {
+      throw new Error("fichier non supporté " + extension);
+    }
+
+    var mdWriter;
+    if (extension === ".odp") {
+      mdWriter = new odpMdWriter();
+    } else {
+      mdWriter = new odtMdWriter();
+    }
+
+    var outputFileName = toFileName(path.basename(filePath, extension));
+    var contentName = path.join(outDir, outputFileName + '-content.xml');
+
+    extractOd(filePath, outputFileName, contentName, outDir);
+
+    return convertToMd(contentName, outputFileName, mdWriter, outDir, splitFiles);
+  });
+};
 
 function toFileName(name) {
-    return name.toLowerCase().replace(/[\s-]+/g, '_').replace(/_{2,}/g, "_");
+  return name.toLowerCase().replace(/[\s-]+/g, '_').replace(/_{2,}/g, "_");
 }
 
-function extractOd(filePath, name, contentName, outDir) {
-    console.log('extract : ' + filePath);
-    var zip = new AdmZip(filePath);
-    var zipEntries = zip.getEntries();
-    zipEntries.forEach(function(val) {
-        if (val.entryName.indexOf("content.xml") >= 0) {
-            //console.log(val.entryName);
-            zip.extractEntryTo(val, outDir, true, true);
-            fs.renameSync(path.join(outDir, val.entryName), contentName);
-        }
-        if (val.entryName.indexOf("Pictures") >= 0) {
-            //console.log(val.entryName);
-            zip.extractEntryTo(val, path.join(outDir, imgDir), false, true);
-            var baseName = path.basename(val.entryName);
-            fs.renameSync(path.join(outDir, imgDir, baseName), path.join(outDir, imgDir, name + '-' + baseName));
-        }
-    });
+function extractOd(filePath, outputFileName, contentName, outDir) {
+  console.log('extract : ' + filePath);
+
+  var zip = new AdmZip(filePath);
+  var zipEntries = zip.getEntries();
+  zipEntries.forEach(function (val) {
+    if (val.entryName.indexOf("content.xml") >= 0) {
+      //console.log(val.entryName);
+      zip.extractEntryTo(val, outDir, true, true);
+      fs.renameSync(path.join(outDir, val.entryName), contentName);
+    }
+    if (val.entryName.indexOf("Pictures") >= 0) {
+      //console.log(val.entryName);
+      zip.extractEntryTo(val, path.join(outDir, imgDir), false, true);
+      var baseName = path.basename(val.entryName);
+      fs.renameSync(path.join(outDir, imgDir, baseName), path.join(outDir, imgDir, outputFileName + '-' + baseName));
+    }
+  });
 }
 
-function convertToMd(contentName, outName, mdWriter, outDir, splitFiles) {
-    return new Promise(function(resolve, reject) {
-        var saxStream = sax.createStream(true, {
-            trim: false,
-            normalize: true,
-            xmlns: false,
-            lowercase: true
-        });
+function convertToMd(contentName, outputFileName, mdWriter, outDir, splitFiles) {
+  return new Promise(function (resolve, reject) {
 
-        saxStream.on("opentag", function(node) {
-
-            if (node.name === "draw:page") {
-                mdWriter.addPage();
-            } else if (node.name === "draw:image") {
-                mdWriter.addImage(outName + '-' + node.attributes["xlink:href"]);
-            } else if (node.name === "text:list") {
-                mdWriter.startList();
-            } else if (node.name === "text:list-item") {
-                mdWriter.addBullet();
-            } else if (node.name === "draw:custom-shape" || node.name === "draw:rect") {
-                mdWriter.startCodeBlock();
-            } else if (node.name === "text:p") {
-                mdWriter.addParagraph();
-            } else if (node.name === "text:h") {
-                mdWriter.startTitle(parseInt(node.attributes["text:outline-level"]));
-            } else if (node.name === "presentation:notes") {
-                mdWriter.startNotes();
-            } else if (node.name === "table:table") {
-                mdWriter.startTable();
-            } else if (node.name === "table:table-row") {
-                mdWriter.startRow();
-            } else if (node.name === "text:line-break") {
-                mdWriter.lineBreak();
-            }
-
-        });
-
-        saxStream.on("closetag", function(node) {
-
-            if (node === "draw:custom-shape" || node === "draw:rect") {
-                mdWriter.endCodeBlock();
-            } else if (node === "text:list") {
-                mdWriter.endList();
-            } else if (node === "presentation:notes") {
-                mdWriter.endNotes();
-            } else if (node === "table:table") {
-                mdWriter.endTable();
-            } else if (node === "table:table-cell") {
-                mdWriter.closeCell();
-            } else if (node === "text:p") {
-                mdWriter.endParagraph();
-            } else if (node === "text:h") {
-                mdWriter.endTitle();
-            }else if (node === "text:list-item") {
-                mdWriter.endBullet();
-            }
-        });
-
-        saxStream.on("end", function() {
-            mdWriter.addEnd();
-        });
-
-        saxStream.on("text", function(t) {
-            mdWriter.addText(t);
-        });
-
-        fs.createReadStream(contentName)
-            .once("readable", function() {
-                console.log('convert : ' + outName);
-            })
-            .pipe(saxStream)
-            .on("end", function() {
-                resolve(mdWriter);
-            })
-            .on("error", reject);
-    }).then(function(mdWriter) {
-        fs.unlink(contentName);
-
-        var promise;
-        var pageNames = [];
-
-        if (!splitFiles && mdWriter.pages) {
-            mdWriter.text = _.map(mdWriter.pages, function(page) {
-                return page.text;
-            }).join("");
-        }
-
-        if (mdWriter.text) {
-            var outMdName = outName + '.md';
-            var outPath = path.join(outDir, outMdName);
-            pageNames.push(outMdName)
-            console.log('write to ' + outPath);
-            promise = fs.writeFileAsync(outPath, mdWriter.text);
-        } else if (mdWriter.pages) {
-            promise = Promise.all(_.map(mdWriter.pages, function(page) {
-                var outMdName = toFileName(page.title) + '.md';
-                var outPath = path.join(outDir, outMdName);
-                pageNames.push(outMdName)
-                console.log('write to ' + outPath);
-                return fs.writeFileAsync(outPath, page.text);
-            }));
-        }
-
-        return promise.then(function() {
-            return pageNames;
-        });
+    var saxStream = sax.createStream(true, {
+      trim: false,
+      normalize: true,
+      xmlns: false,
+      lowercase: true
     });
+
+    saxStream.on("opentag", function (node) {
+
+      if (node.name === "draw:page") {
+        mdWriter.addPage();
+      } else if (node.name === "draw:image") {
+        mdWriter.addImage(outputFileName + '-' + node.attributes["xlink:href"]);
+      } else if (node.name === "text:list") {
+        mdWriter.startList();
+      } else if (node.name === "text:list-item") {
+        mdWriter.addBullet();
+      } else if (node.name === "draw:custom-shape" || node.name === "draw:rect") {
+        mdWriter.startCodeBlock();
+      } else if (node.name === "text:p") {
+        mdWriter.addParagraph();
+      } else if (node.name === "text:h") {
+        mdWriter.startTitle(parseInt(node.attributes["text:outline-level"]));
+      } else if (node.name === "presentation:notes") {
+        mdWriter.startNotes();
+      } else if (node.name === "table:table") {
+        mdWriter.startTable();
+      } else if (node.name === "table:table-row") {
+        mdWriter.startRow();
+      } else if (node.name === "text:line-break") {
+        mdWriter.lineBreak();
+      }
+
+    });
+
+    saxStream.on("closetag", function (node) {
+
+      if (node === "draw:custom-shape" || node === "draw:rect") {
+        mdWriter.endCodeBlock();
+      } else if (node === "text:list") {
+        mdWriter.endList();
+      } else if (node === "presentation:notes") {
+        mdWriter.endNotes();
+      } else if (node === "table:table") {
+        mdWriter.endTable();
+      } else if (node === "table:table-cell") {
+        mdWriter.closeCell();
+      } else if (node === "text:p") {
+        mdWriter.endParagraph();
+      } else if (node === "text:h") {
+        mdWriter.endTitle();
+      } else if (node === "text:list-item") {
+        mdWriter.endBullet();
+      }
+    });
+
+    saxStream.on("end", function () {
+      console.log('end');
+      mdWriter.addEnd();
+    });
+
+    saxStream.on("text", function (text) {
+      mdWriter.addText(text);
+    });
+
+    fs.createReadStream(contentName)
+      .once("readable", function () {
+        console.log('convert : ' + outputFileName);
+      })
+      .pipe(saxStream)
+      .on("end", function () {
+        resolve(mdWriter);
+      })
+      .on("error", reject);
+
+  }).then(function (mdWriter) {
+
+    fs.unlink(contentName);
+
+    var promise;
+    var pageNames = [];
+
+    if (!splitFiles && mdWriter.pages) {
+      mdWriter.text = _.map(mdWriter.pages, function (page) {
+        return page.text;
+      }).join("");
+    }
+
+    if (mdWriter.text) {
+      var outMdName = outputFileName + '.md';
+      var outPath = path.join(outDir, outMdName);
+      pageNames.push(outMdName);
+      console.log('write to ' + outPath);
+      promise = fs.writeFileAsync(outPath, mdWriter.text);
+    } else if (mdWriter.pages) {
+      promise = Promise.all(_.map(mdWriter.pages, function (page) {
+        var outMdName = toFileName(page.title) + '.md';
+        var outPath = path.join(outDir, outMdName);
+        pageNames.push(outMdName);
+        console.log('write to ' + outPath);
+        return fs.writeFileAsync(outPath, page.text);
+      }));
+    }
+
+    return promise.then(function () {
+      return pageNames;
+    });
+  });
 }

--- a/lib/ODPMDWriter.js
+++ b/lib/ODPMDWriter.js
@@ -1,139 +1,129 @@
 'use strict';
 
 function ODPMDWriter() {
-    this.text = "";
-    this.inCodeBlock = false;
-    this.inNotes = false;
-    this.listLevel = 0;
-    this.titreAdded = false;
-    this.mainTitleAdded = false;
-    this.firstPage = false;
+  this.text = "";
+  this.inCodeBlock = false;
+  this.inNotes = false;
+  this.listLevel = 0;
+  this.titreAdded = false;
+  this.mainTitleAdded = false;
+  this.firstPage = false;
 }
 
-ODPMDWriter.prototype = {
-    addPage: function() {
-        this.text += "\n\n\n\n";
-        this.titreAdded = false;
-        this.firstPage = true;
-    },
+ODPMDWriter.prototype.addPage = function () {
+  this.text += "\n\n\n\n";
+  this.titreAdded = false;
+  this.firstPage = true;
+};
 
-    addParagraph: function() {
-        if (this.inCodeBlock || this.inNotes) {
-            this.text += "\n";
-        }
-    },
+ODPMDWriter.prototype.addParagraph = function () {
+  if (this.inCodeBlock || this.inNotes) {
+    this.text += "\n";
+  }
+};
 
-    endParagraph : function() {
+ODPMDWriter.prototype.endParagraph = function () {};
 
-    },
+ODPMDWriter.prototype.addText = function (text) {
+  if (this.firstPage && !this.mainTitleAdded) {
+    this.text = '#' + text + '\n\n<!-- .slide: class="page-title" -->\n\n\n\n';
+    this.mainTitleAdded = true;
+  } else if (!this.titreAdded) {
+    this.text += "## " + text + "\n";
+    this.titreAdded = true;
+  } else {
+    this.text += text;
+  }
+};
 
-    addText: function(text) {
-        if (this.firstPage && !this.mainTitleAdded) {
-            this.text = '#' + text + '\n\n<!-- .slide: class="page-title" -->\n\n\n\n';
-            this.mainTitleAdded = true;
-        } else if (!this.titreAdded) {
-            this.text += "## " + text + "\n";
-            this.titreAdded = true;
-        } else {
-            this.text += text;
-        }
-    },
+ODPMDWriter.prototype.addImage = function (path) {
+  this.text += "\n\n![](ressources/images/" + path.replace("Pictures/", "") + ")\n";
+};
 
-    addImage: function(path) {
-        this.text += "\n\n![](ressources/images/" + path.replace("Pictures/", "") + ")\n";
-    },
+ODPMDWriter.prototype.startList = function () {
+  this.listLevel++;
+  if (this.listLevel == 1 && this.text[this.text.length - 1] !== '\n') {
+    this.text += '\n';
+  }
+};
 
-    startList: function() {
-        this.listLevel++;
-        if (this.listLevel == 1 && this.text[this.text.length - 1] !== '\n') {
-            this.text += '\n';
-        }
-    },
+ODPMDWriter.prototype.endList = function () {
+  this.listLevel--;
+  this.text += '\n';
+};
 
-    endList: function() {
-        this.listLevel--;
-        this.text += '\n';
-    },
+ODPMDWriter.prototype.addBullet = function () {
+  if (!this.listLevel) {
+    console.warning("not in a list");
+  }
+  this.text += "\n" + new Array(this.listLevel).join("\t") + "- ";
+};
 
-    addBullet: function() {
-        if (!this.listLevel) {
-            console.warning("not in a list");
-        }
-        this.text += "\n" + new Array(this.listLevel).join("\t") + "- ";
-    },
+ODPMDWriter.prototype.endBullet = function () {};
 
-    endBullet : function() {
-    },
+ODPMDWriter.prototype.addEnd = function () {
+  this.text += "\n\n\n\n<!-- .slide: class=\"page-questions\" -->\n\n\n\n<!-- .slide: class=\"page-tp1\" -->";
+};
 
-    addEnd: function() {
-        this.text += "\n\n\n\n<!-- .slide: class=\"page-questions\" -->\n\n\n\n<!-- .slide: class=\"page-tp1\" -->";
-    },
+ODPMDWriter.prototype.startCodeBlock = function () {
+  this.tmp = this.text;
+  this.text = "";
+  if (this.tmp[this.tmp.length - 1] !== '\n') {
+    this.text += "\n";
+  }
+  this.text += "\n```";
+  this.inCodeBlock = true;
+};
 
-    startCodeBlock: function() {
-        this.tmp = this.text;
-        this.text = "";
-        if (this.tmp[this.tmp.length - 1] !== '\n') {
-            this.text += "\n";
-        }
-        this.text += "\n```";
-        this.inCodeBlock = true;
-    },
+ODPMDWriter.prototype.endCodeBlock = function () {
+  this.text += "\n```\n";
+  this.inCodeBlock = false;
+  var codeBlock = this.text;
+  this.text = this.tmp;
+  this.text += codeBlock.replace(/\n{3}/g, "\n\n");
+};
 
-    endCodeBlock: function() {
-        this.text += "\n```\n";
-        this.inCodeBlock = false;
-        var codeBlock = this.text;
-        this.text = this.tmp;
-        this.text += codeBlock.replace(/\n{3}/g, "\n\n");
-    },
+ODPMDWriter.prototype.startNotes = function () {
+  this.text += "\nNotes :\n";
+  this.inNotes = true;
+};
 
-    startNotes: function() {
-        this.text += "\nNotes :\n";
-        this.inNotes = true;
-    },
+ODPMDWriter.prototype.endNotes = function () {
+  this.inNotes = false;
+};
 
-    endNotes: function() {
-        this.inNotes = false;
-    },
+ODPMDWriter.prototype.startTable = function () {
+  this.inTable = true;
+  this.rowNumber = 0;
+  this.colNumber = 0;
+};
 
+ODPMDWriter.prototype.endTable = function () {
+  this.inTable = false;
+};
 
-    startTable: function() {
-        this.inTable = true;
-        this.rowNumber = 0;
-        this.colNumber = 0;
-    },
+ODPMDWriter.prototype.startRow = function () {
+  this.text += "\n|";
+  if (this.rowNumber == 1) {
+    //If header was written we write separation line
+    this.text += new Array(this.colNumber + 1).join("---|") + "\n|";
+  }
+  this.rowNumber++;
+};
 
-    endTable: function() {
-        this.inTable = false;
-    },
+ODPMDWriter.prototype.closeCell = function () {
+  if (this.rowNumber == 1) {
+    this.colNumber++;
+  }
+  this.text += "|";
+};
 
-    startRow: function() {
-        this.text += "\n|";
-        if (this.rowNumber == 1) {
-            //If header was written we write separation line
-            this.text += Array(this.colNumber + 1).join("---|") + "\n|";
-        }
-        this.rowNumber++;
-    },
+ODPMDWriter.prototype.startTitle = function () {};
 
-    closeCell: function() {
-        if (this.rowNumber == 1) {
-            this.colNumber++;
-        }
-        this.text += "|";
-    },
+ODPMDWriter.prototype.endTitle = function () {};
 
-    startTitle : function() {
-
-    },
-
-    endTitle : function() {
-
-    },
-
-    lineBreak : function() {
-        this.text += "  \n";
-    }
+ODPMDWriter.prototype.lineBreak = function () {
+  this.text += "  \n";
 };
 
 module.exports = ODPMDWriter;

--- a/lib/ODPMDWriter.js
+++ b/lib/ODPMDWriter.js
@@ -5,9 +5,9 @@ function ODPMDWriter() {
   this.inCodeBlock = false;
   this.inNotes = false;
   this.listLevel = 0;
-  this.titreAdded = false;
   this.mainTitleAdded = false;
   this.firstPage = false;
+  this.titreAdded = false;
 }
 
 ODPMDWriter.prototype.addPage = function () {
@@ -26,7 +26,7 @@ ODPMDWriter.prototype.endParagraph = function () {};
 
 ODPMDWriter.prototype.addText = function (text) {
   if (this.firstPage && !this.mainTitleAdded) {
-    this.text = '#' + text + '\n\n<!-- .slide: class="page-title" -->\n\n\n\n';
+    this.text = '# ' + text + '\n\n<!-- .slide: class="page-title" -->\n\n\n\n';
     this.mainTitleAdded = true;
   } else if (!this.titreAdded) {
     this.text += "## " + text + "\n";

--- a/lib/ODTMDWriter.js
+++ b/lib/ODTMDWriter.js
@@ -13,6 +13,14 @@ function ODTMDWriter() {
   this.pages = [];
 }
 
+ODTMDWriter.prototype.newFile = function () {
+  this.pages.push({
+    title: this.currentTitle,
+    text: this.text
+  });
+  this.text = "";
+  this.currentTitle = "";
+};
 
 ODTMDWriter.prototype.addPage = function () {
   this.text += "\n\n\n\n";
@@ -24,36 +32,10 @@ ODTMDWriter.prototype.addParagraph = function () {
   //this.text += "\n";
 };
 
-ODTMDWriter.prototype.lineBreak = function () {
-  this.text += "  \n";
-};
-
 ODTMDWriter.prototype.endParagraph = function () {
   if (!this.listLevel) {
-    this.text += "  \n";
+    this.text += "\n";
   }
-};
-
-ODTMDWriter.prototype.startTitle = function (level) {
-  if (level === 1) {
-    this.newFile();
-  }
-  this.text += new Array(level + 2).join("#") + " ";
-  this.titleLevel = level;
-};
-
-ODTMDWriter.prototype.newFile = function () {
-  this.pages.push({
-    title: this.currentTitle,
-    text: this.text
-  });
-  this.text = "";
-  this.currentTitle = "";
-};
-
-ODTMDWriter.prototype.endTitle = function () {
-  this.titleLevel = 0;
-  this.text += "\n\n";
 };
 
 ODTMDWriter.prototype.addText = function (text) {
@@ -62,7 +44,7 @@ ODTMDWriter.prototype.addText = function (text) {
   }
 
   if (this.firstPage && !this.mainTitleAdded) {
-    this.text = '#' + text + '\n\n<!-- .slide: class="page-title" -->\n\n\n\n';
+    this.text = '# ' + text + '\n\n<!-- .slide: class="page-title" -->\n\n\n\n';
     this.mainTitleAdded = true;
   } else {
     this.text += text;
@@ -144,5 +126,21 @@ ODTMDWriter.prototype.closeCell = function () {
   this.text += "|";
 };
 
+ODTMDWriter.prototype.startTitle = function (level) {
+  if (level === 1) {
+    this.newFile();
+  }
+  this.text += new Array(level + 2).join("#") + " ";
+  this.titleLevel = level;
+};
+
+ODTMDWriter.prototype.endTitle = function () {
+  this.titleLevel = 0;
+  this.text += "\n\n";
+};
+
+ODTMDWriter.prototype.lineBreak = function () {
+  this.text += "  \n";
+};
 
 module.exports = ODTMDWriter;

--- a/lib/ODTMDWriter.js
+++ b/lib/ODTMDWriter.js
@@ -1,143 +1,148 @@
 'use strict';
 
 function ODTMDWriter() {
-    this.text = "";
-    this.inCodeBlock = false;
-    this.inNotes = false;
-    this.listLevel = 0;
-    this.mainTitleAdded = false;
-    this.firstPage = false;
-    this.titleLevel = 0;
+  this.text = "";
+  this.inCodeBlock = false;
+  this.inNotes = false;
+  this.listLevel = 0;
+  this.mainTitleAdded = false;
+  this.firstPage = false;
+  this.titleLevel = 0;
 
-    this.currentTitle = "first_page";
-    this.pages = [];
+  this.currentTitle = "first_page";
+  this.pages = [];
 }
 
-ODTMDWriter.prototype = {
 
-    addParagraph: function() {
-        //this.text += "\n";
-    },
-
-    lineBreak : function() {
-        this.text += "  \n";
-    },
-
-    endParagraph: function() {
-        if (!this.listLevel) {
-            this.text += "  \n";
-        }
-    },
-
-    startTitle: function(level) {
-        if (level === 1) {
-            this.newFile();
-        }
-        this.text += Array(level + 2).join("#") + " ";
-        this.titleLevel = level;
-    },
-
-    newFile: function() {
-        this.pages.push({
-            title: this.currentTitle,
-            text: this.text
-        });
-        this.text = "";
-        this.currentTitle = "";
-    },
-
-    endTitle: function() {
-        this.titleLevel = 0;
-        this.text += "\n";
-    },
-
-    addText: function(text) {
-        if (this.titleLevel === 1) {
-            this.currentTitle += text;
-        }
-
-        if (this.firstPage && !this.mainTitleAdded) {
-            this.text = '#' + text + '\n\n<!-- .slide: class="page-title" -->\n\n\n\n';
-            this.mainTitleAdded = true;
-        } else {
-            this.text += text;
-        }
-    },
-
-    addImage: function(path) {
-        this.text += "\n\n![](ressources/images/" + path.replace("Pictures/", "") + ")\n";
-    },
-
-    startList: function() {
-        this.listLevel++;
-        if (this.text[this.text.length - 1] !== '\n') {
-            this.text += '\n';
-        }
-    },
-
-    endList: function() {
-        this.listLevel--;
-        this.text += '\n';
-    },
-
-    addBullet: function() {
-        if (!this.listLevel) {
-            console.warning("not in a list");
-        }
-        this.text += new Array(this.listLevel).join("\t") + "- ";
-    },
-
-    endBullet : function() {
-        this.text += "\n";
-    },
-
-    addEnd: function() {
-        this.newFile();
-    },
-
-    startCodeBlock: function() {
-        this.tmp = this.text;
-        this.text = "";
-        if (this.tmp[this.tmp.length - 1] !== '\n') {
-            this.text += "\n";
-        }
-        this.text += "\n```";
-        this.inCodeBlock = true;
-    },
-
-    endCodeBlock: function() {
-        this.text += "\n```\n";
-        this.inCodeBlock = false;
-        var codeBlock = this.text;
-        this.text = this.tmp;
-        this.text += codeBlock.replace(/\n{3}/g, "\n\n");
-    },
-
-    startTable: function() {
-        this.inTable = true;
-        this.rowNumber = 0;
-        this.colNumber = 0;
-    },
-
-    endTable: function() {
-        this.inTable = false;
-    },
-
-    startRow: function() {
-        this.text += "\n|";
-        if (this.rowNumber == 1) {
-            //If header was written we write separation line
-            this.text += Array(this.colNumber + 1).join("---|") + "\n|";
-        }
-        this.rowNumber++;
-    },
-
-    closeCell: function() {
-        if (this.rowNumber == 1) {
-            this.colNumber++;
-        }
-        this.text += "|";
-    }
+ODTMDWriter.prototype.addPage = function () {
+  this.text += "\n\n\n\n";
+  this.mainTitleAdded = false;
+  this.firstPage = true;
 };
+
+ODTMDWriter.prototype.addParagraph = function () {
+  //this.text += "\n";
+};
+
+ODTMDWriter.prototype.lineBreak = function () {
+  this.text += "  \n";
+};
+
+ODTMDWriter.prototype.endParagraph = function () {
+  if (!this.listLevel) {
+    this.text += "  \n";
+  }
+};
+
+ODTMDWriter.prototype.startTitle = function (level) {
+  if (level === 1) {
+    this.newFile();
+  }
+  this.text += new Array(level + 2).join("#") + " ";
+  this.titleLevel = level;
+};
+
+ODTMDWriter.prototype.newFile = function () {
+  this.pages.push({
+    title: this.currentTitle,
+    text: this.text
+  });
+  this.text = "";
+  this.currentTitle = "";
+};
+
+ODTMDWriter.prototype.endTitle = function () {
+  this.titleLevel = 0;
+  this.text += "\n\n";
+};
+
+ODTMDWriter.prototype.addText = function (text) {
+  if (this.titleLevel === 1) {
+    this.currentTitle += text;
+  }
+
+  if (this.firstPage && !this.mainTitleAdded) {
+    this.text = '#' + text + '\n\n<!-- .slide: class="page-title" -->\n\n\n\n';
+    this.mainTitleAdded = true;
+  } else {
+    this.text += text;
+  }
+};
+
+ODTMDWriter.prototype.addImage = function (path) {
+  this.text += "\n\n![](ressources/images/" + path.replace("Pictures/", "") + ")\n";
+};
+
+ODTMDWriter.prototype.startList = function () {
+  this.listLevel++;
+  if (this.text[this.text.length - 1] !== '\n') {
+    this.text += '\n';
+  }
+};
+
+ODTMDWriter.prototype.endList = function () {
+  this.listLevel--;
+  this.text += '\n';
+};
+
+ODTMDWriter.prototype.addBullet = function () {
+  if (!this.listLevel) {
+    console.warning("not in a list");
+  }
+  this.text += new Array(this.listLevel).join("\t") + "- ";
+};
+
+ODTMDWriter.prototype.endBullet = function () {
+  this.text += "\n";
+};
+
+ODTMDWriter.prototype.addEnd = function () {
+  this.newFile();
+};
+
+ODTMDWriter.prototype.startCodeBlock = function () {
+  this.tmp = this.text;
+  this.text = "";
+  if (this.tmp[this.tmp.length - 1] !== '\n') {
+    this.text += "\n";
+  }
+  this.text += "\n```";
+  this.inCodeBlock = true;
+};
+
+ODTMDWriter.prototype.endCodeBlock = function () {
+  this.text += "\n```\n";
+  this.inCodeBlock = false;
+  var codeBlock = this.text;
+  this.text = this.tmp;
+  this.text += codeBlock.replace(/\n{3}/g, "\n\n");
+};
+
+ODTMDWriter.prototype.startTable = function () {
+  this.inTable = true;
+  this.rowNumber = 0;
+  this.colNumber = 0;
+};
+
+ODTMDWriter.prototype.endTable = function () {
+  this.inTable = false;
+};
+
+ODTMDWriter.prototype.startRow = function () {
+  this.text += "\n|";
+  if (this.rowNumber == 1) {
+    //If header was written we write separation line
+    this.text += new Array(this.colNumber + 1).join("---|") + "\n|";
+  }
+  this.rowNumber++;
+};
+
+ODTMDWriter.prototype.closeCell = function () {
+  if (this.rowNumber == 1) {
+    this.colNumber++;
+  }
+  this.text += "|";
+};
+
 
 module.exports = ODTMDWriter;


### PR DESCRIPTION
- correction méthode manquante pour les ODT
- ajout du support pour les `ObjectReplacements`
- export des `ObjectReplacements` en `.svm`
- réorganisation des méthodes entre `ODP` et `ODT`
- ajout d'un espace pour les 'header level 0'
- division des méthodes d'extraction du contenu
- nettoyage du code
